### PR TITLE
docs(migrations): document the shomer-migrate entrypoint

### DIFF
--- a/packages/bdd/migrations/src/shomer_migrations/migrate.py
+++ b/packages/bdd/migrations/src/shomer_migrations/migrate.py
@@ -32,4 +32,9 @@ def upgrade(revision: str = "head") -> None:
 
 
 def main() -> None:
+    """Console-script entrypoint (``shomer-migrate``).
+
+    Applies migrations up to the revision given as the first CLI argument,
+    or to ``head`` when none is provided.
+    """
     upgrade(sys.argv[1] if len(sys.argv) > 1 else "head")


### PR DESCRIPTION
Petit changement de documentation sur `migrate.py` pour observer le comportement de la pipeline sur le composant `migrations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)