### PR TITLE
fix(job): refresh grype allowlist against the current base image

### DIFF
--- a/packages/job/.grype.yaml
+++ b/packages/job/.grype.yaml
@@ -16,112 +16,13 @@
 #      again under --fail-on high.
 
 ignore:
-  # CVE-2026-7210 (Critical) — upstream Chainguard python-3.14 in
-  # cgr.dev/chainguard/python:3.14.6-r0 (now explicitly pinned in the
-  # Dockerfile next door, no more :latest drift). The CVE has been
-  # carried across r1 / r2 / r0-of-3.14.6 without an upstream fix —
-  # we re-evaluate by the expiration; in the meantime the version pin
-  # below keeps the ignore scoped to the exact apk shipping in our
-  # image, so any Dependabot bump of the FROM line will trip the
-  # mismatch and force a fresh review.
-  # expires: 2026-06-27
-  - vulnerability: CVE-2026-7210
-    reason: "Upstream Chainguard python apk on the pinned base; awaiting patched build."
-    package:
-      name: python-3.14
-      version: 3.14.6-r0
-      type: apk
-
-  # CVE-2026-9669 (High) — surfaced when Chainguard re-built the apk
-  # at 3.14.6-r0. Same upstream as CVE-2026-7210, same review cadence;
-  # the weekly grype-allowlist-sweep workflow will flag both the
-  # moment the version pin no longer matches what's in the image.
-  # expires: 2026-06-27
-  - vulnerability: CVE-2026-9669
-    reason: "Upstream Chainguard python apk on the pinned base; awaiting patched build."
-    package:
-      name: python-3.14
-      version: 3.14.6-r0
-      type: apk
-
-  # CVE-2026-7210 (High) — same upstream CVE, but grype now reports it
-  # on the python-3.14-base subpackage (the entry above only pins the
-  # python-3.14 package, so the -base finding slipped past --fail-on
-  # high). Fixed in 3.14.6-r1; the version pin auto-resolves the ignore
-  # once the base image is bumped.
-  # expires: 2026-06-27
-  - vulnerability: CVE-2026-7210
-    reason: "Upstream Chainguard python-3.14-base apk on the pinned base; fixed in 3.14.6-r1, pending a base-image bump."
-    package:
-      name: python-3.14-base
-      version: 3.14.6-r0
-      type: apk
-
-  # CVE-2026-9669 (High) — python-3.14-base subpackage, same upstream.
-  # expires: 2026-06-27
-  - vulnerability: CVE-2026-9669
-    reason: "Upstream Chainguard python-3.14-base apk on the pinned base; fixed in 3.14.6-r1, pending a base-image bump."
-    package:
-      name: python-3.14-base
-      version: 3.14.6-r0
-      type: apk
-
-  # CVE-2026-44432 (High) — Chainguard py3-pip-wheel apk on the pinned base.
-  # Fixed upstream in 26.1.2-r1; the version pin below auto-resolves this
-  # ignore the moment the base image is bumped to ship it (Dependabot /
-  # grype-allowlist-sweep). Short expiry to force that bump.
-  # expires: 2026-07-02
-  - vulnerability: CVE-2026-44432
-    reason: "Chainguard py3-pip-wheel apk on the pinned base; fixed in 26.1.2-r1, pending a base-image bump."
-    package:
-      name: py3-pip-wheel
-      version: 26.1.2-r0
-      type: apk
-
-  # CVE-2026-11940 (High) — Chainguard python-3.14 apk on the pinned base;
-  # fixed in 3.14.6-r3, pending a base-image bump. The version pin auto-
-  # resolves this once the base is bumped.
-  # expires: 2026-08-02
-  - vulnerability: CVE-2026-11940
-    reason: "Upstream Chainguard python-3.14 apk on the pinned base; fixed in 3.14.6-r3, pending a base-image bump."
-    package:
-      name: python-3.14
-      version: 3.14.6-r0
-      type: apk
-
-  # CVE-2026-11940 (High) — python-3.14-base subpackage, same upstream.
-  # expires: 2026-08-02
-  - vulnerability: CVE-2026-11940
-    reason: "Upstream Chainguard python-3.14-base apk on the pinned base; fixed in 3.14.6-r3, pending a base-image bump."
-    package:
-      name: python-3.14-base
-      version: 3.14.6-r0
-      type: apk
-
-  # CVE-2026-11972 (High) — Chainguard python-3.14 apk on the pinned base.
-  # expires: 2026-08-02
-  - vulnerability: CVE-2026-11972
-    reason: "Upstream Chainguard python-3.14 apk on the pinned base; fixed in 3.14.6-r3, pending a base-image bump."
-    package:
-      name: python-3.14
-      version: 3.14.6-r0
-      type: apk
-
-  # CVE-2026-11972 (High) — python-3.14-base subpackage, same upstream.
-  # expires: 2026-08-02
-  - vulnerability: CVE-2026-11972
-    reason: "Upstream Chainguard python-3.14-base apk on the pinned base; fixed in 3.14.6-r3, pending a base-image bump."
-    package:
-      name: python-3.14-base
-      version: 3.14.6-r0
-      type: apk
 
   # CVE-2026-15308 (High) — Chainguard python-3.14 apk on the pinned base;
   # no upstream fix yet.
-  # expires: 2026-08-02
+  # expires: 2026-08-03
   - vulnerability: CVE-2026-15308
     reason: "Upstream Chainguard python-3.14 apk on the pinned base; no patched build yet."
     package:
       name: python-3.14
-      version: 3.14.6-r0
+      version: 3.14.6-r3
       type: apk

--- a/packages/job/Dockerfile
+++ b/packages/job/Dockerfile
@@ -3,7 +3,7 @@
 # Multi-stage build on Chainguard distroless images. See api's
 # Dockerfile for the rationale.
 
-FROM cgr.dev/chainguard/python:latest-dev@sha256:fa7db0816e4dd581d4b4a76edda591804a71788b6a46e46af0b435dad4552642 AS builder
+FROM cgr.dev/chainguard/python:latest-dev@sha256:31d318170df60ddec4b04ed595cbe79c33eeb2cf94f9676db6f9eaf46542e6be AS builder
 
 WORKDIR /app
 COPY pyproject.toml ./
@@ -12,7 +12,7 @@ COPY src ./src
 RUN python -m venv /app/venv \
  && /app/venv/bin/pip install --no-cache-dir .
 
-FROM cgr.dev/chainguard/python:latest@sha256:33334c2bf93fd99e6b3c42b518cc44bb5277a954826cdb4f9275ef95818d7eb7
+FROM cgr.dev/chainguard/python:latest@sha256:2c6a2e8bdeb1336cd8545d3586d1c1e5b4f7564ef00924b0447ebfbe57a549ee
 
 COPY --from=builder /app/venv /app/venv
 ENV PATH="/app/venv/bin:$PATH"


### PR DESCRIPTION
Automated grype refresh for `job` (scripts/grype-refresh.py).
- base `:latest-dev` re-pinned `sha256:fa7db0816e4d…` → `sha256:31d318170df6…`
- base `:latest` re-pinned `sha256:33334c2bf93f…` → `sha256:2c6a2e8bdeb1…`

## 🛡️ grype allowlist sync — `job`

Built `packages/job/Dockerfile` and scanned the resulting image with grype. Updated `packages/job/.grype.yaml`:

### 🔁 Version-pin bumped (CVE still matched)

- **CVE-2026-15308** — `python-3.14` `3.14.6-r0` → `3.14.6-r3`

### ✅ Resolved (CVE no longer matched)

- **CVE-2026-7210** — `python-3.14` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-9669** — `python-3.14` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-7210** — `python-3.14-base` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-9669** — `python-3.14-base` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-44432** — `py3-pip-wheel` `26.1.2-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-11940** — `python-3.14` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-11940** — `python-3.14-base` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-11972** — `python-3.14` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-11972** — `python-3.14-base` `3.14.6-r0` no longer reported on the new image. Entry removed.


Refs #118