### PR TITLE
fix(migrations): refresh grype allowlist against the current base image

### DIFF
--- a/packages/bdd/migrations/.grype.yaml
+++ b/packages/bdd/migrations/.grype.yaml
@@ -11,99 +11,13 @@
 # auto-resolves each ignore the moment the base image ships a patched apk.
 
 ignore:
-  # expires: 2026-06-27
-  - vulnerability: CVE-2026-7210
-    reason: "Upstream Chainguard python apk on the pinned base; awaiting patched build."
-    package:
-      name: python-3.14
-      version: 3.14.6-r0
-      type: apk
-
-  # expires: 2026-06-27
-  - vulnerability: CVE-2026-9669
-    reason: "Upstream Chainguard python apk on the pinned base; awaiting patched build."
-    package:
-      name: python-3.14
-      version: 3.14.6-r0
-      type: apk
-
-  # CVE-2026-7210 (High) — same upstream CVE, but grype now reports it
-  # on the python-3.14-base subpackage (the entry above only pins the
-  # python-3.14 package, so the -base finding slipped past --fail-on
-  # high). Fixed in 3.14.6-r1; the version pin auto-resolves the ignore
-  # once the base image is bumped.
-  # expires: 2026-06-27
-  - vulnerability: CVE-2026-7210
-    reason: "Upstream Chainguard python-3.14-base apk on the pinned base; fixed in 3.14.6-r1, pending a base-image bump."
-    package:
-      name: python-3.14-base
-      version: 3.14.6-r0
-      type: apk
-
-  # CVE-2026-9669 (High) — python-3.14-base subpackage, same upstream.
-  # expires: 2026-06-27
-  - vulnerability: CVE-2026-9669
-    reason: "Upstream Chainguard python-3.14-base apk on the pinned base; fixed in 3.14.6-r1, pending a base-image bump."
-    package:
-      name: python-3.14-base
-      version: 3.14.6-r0
-      type: apk
-
-  # CVE-2026-44432 (High) — Chainguard py3-pip-wheel apk on the pinned base.
-  # Fixed upstream in 26.1.2-r1; the version pin below auto-resolves this
-  # ignore once the base image is bumped to ship it.
-  # expires: 2026-07-02
-  - vulnerability: CVE-2026-44432
-    reason: "Chainguard py3-pip-wheel apk on the pinned base; fixed in 26.1.2-r1, pending a base-image bump."
-    package:
-      name: py3-pip-wheel
-      version: 26.1.2-r0
-      type: apk
-
-  # CVE-2026-11940 (High) — Chainguard python-3.14 apk on the pinned base;
-  # fixed in 3.14.6-r3, pending a base-image bump. The version pin auto-
-  # resolves this once the base is bumped.
-  # expires: 2026-08-02
-  - vulnerability: CVE-2026-11940
-    reason: "Upstream Chainguard python-3.14 apk on the pinned base; fixed in 3.14.6-r3, pending a base-image bump."
-    package:
-      name: python-3.14
-      version: 3.14.6-r0
-      type: apk
-
-  # CVE-2026-11940 (High) — python-3.14-base subpackage, same upstream.
-  # expires: 2026-08-02
-  - vulnerability: CVE-2026-11940
-    reason: "Upstream Chainguard python-3.14-base apk on the pinned base; fixed in 3.14.6-r3, pending a base-image bump."
-    package:
-      name: python-3.14-base
-      version: 3.14.6-r0
-      type: apk
-
-  # CVE-2026-11972 (High) — Chainguard python-3.14 apk on the pinned base.
-  # expires: 2026-08-02
-  - vulnerability: CVE-2026-11972
-    reason: "Upstream Chainguard python-3.14 apk on the pinned base; fixed in 3.14.6-r3, pending a base-image bump."
-    package:
-      name: python-3.14
-      version: 3.14.6-r0
-      type: apk
-
-  # CVE-2026-11972 (High) — python-3.14-base subpackage, same upstream.
-  # expires: 2026-08-02
-  - vulnerability: CVE-2026-11972
-    reason: "Upstream Chainguard python-3.14-base apk on the pinned base; fixed in 3.14.6-r3, pending a base-image bump."
-    package:
-      name: python-3.14-base
-      version: 3.14.6-r0
-      type: apk
 
   # CVE-2026-15308 (High) — Chainguard python-3.14 apk on the pinned base;
   # no upstream fix yet.
-  # expires: 2026-08-02
+  # expires: 2026-08-03
   - vulnerability: CVE-2026-15308
     reason: "Upstream Chainguard python-3.14 apk on the pinned base; no patched build yet."
     package:
       name: python-3.14
-      version: 3.14.6-r0
+      version: 3.14.6-r3
       type: apk

--- a/packages/bdd/migrations/Dockerfile
+++ b/packages/bdd/migrations/Dockerfile
@@ -14,7 +14,7 @@
 # DRIVER selects the DB driver. postgres (psycopg) and mysql (PyMySQL) work on
 # distroless; mssql/pyodbc needs system unixODBC + a different base.
 
-FROM cgr.dev/chainguard/python:latest-dev@sha256:d45c16a1807036a402f2101a1e82863468c923d85a2ed4817b2b12b2f0ee54dd AS builder
+FROM cgr.dev/chainguard/python:latest-dev@sha256:31d318170df60ddec4b04ed595cbe79c33eeb2cf94f9676db6f9eaf46542e6be AS builder
 
 ARG DRIVER=postgres
 
@@ -25,7 +25,7 @@ COPY migrations ./migrations
 RUN python -m venv /app/venv \
  && /app/venv/bin/pip install --no-cache-dir "./database[${DRIVER}]" ./migrations
 
-FROM cgr.dev/chainguard/python:latest@sha256:6a9e1eed2c9f3ea955a63455c0417a2177f5ce669d2587da6f7d01d738c683d6
+FROM cgr.dev/chainguard/python:latest@sha256:2c6a2e8bdeb1336cd8545d3586d1c1e5b4f7564ef00924b0447ebfbe57a549ee
 
 COPY --from=builder /app/venv /app/venv
 ENV PATH="/app/venv/bin:$PATH"


### PR DESCRIPTION
Automated grype refresh for `migrations` (scripts/grype-refresh.py).
- base `:latest-dev` re-pinned `sha256:d45c16a18070…` → `sha256:31d318170df6…`
- base `:latest` re-pinned `sha256:6a9e1eed2c9f…` → `sha256:2c6a2e8bdeb1…`

## 🛡️ grype allowlist sync — `migrations`

Built `packages/migrations/Dockerfile` and scanned the resulting image with grype. Updated `packages/migrations/.grype.yaml`:

### 🔁 Version-pin bumped (CVE still matched)

- **CVE-2026-15308** — `python-3.14` `3.14.6-r0` → `3.14.6-r3`

### ✅ Resolved (CVE no longer matched)

- **CVE-2026-7210** — `python-3.14` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-9669** — `python-3.14` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-7210** — `python-3.14-base` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-9669** — `python-3.14-base` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-44432** — `py3-pip-wheel` `26.1.2-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-11940** — `python-3.14` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-11940** — `python-3.14-base` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-11972** — `python-3.14` `3.14.6-r0` no longer reported on the new image. Entry removed.
- **CVE-2026-11972** — `python-3.14-base` `3.14.6-r0` no longer reported on the new image. Entry removed.


Refs #118